### PR TITLE
Add EXTRA_CONFIGURE_FLAGS parameter to debian/rules

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -6,8 +6,14 @@ DPKG_EXPORT_BUILDFLAGS = 1
 
 # assumes that CWD is root of gpdb source
 GPDB_SRC_DIR := $(shell pwd)
-VERSION := $(shell ./getversion | tr " " ".")
+GPDB_VERSION := $(shell ./getversion | tr " " ".")
 PACKAGE := $(shell cat debian/control | egrep "^Package: " | cut -d " " -f 2)
+
+IS_GPDB6 := $(shell expr ${GPDB_VERSION} : "\(^6\.[0-9]\+\.[0-9]\+\)")
+
+ifdef IS_GPDB6
+	EXTRA_CONFIGURE_FLAGS := --without-zstd
+endif
 
 # This destination should NOT be debian/tmp, where certain packaging info stored and erased via dh_prep
 # Also, this directory is duplicated in the "debian/install" file
@@ -29,7 +35,8 @@ override_dh_auto_configure: orca
         --with-libs=${DEBIAN_DESTINATION}/lib \
         --with-includes=${DEBIAN_DESTINATION}/include \
         --prefix=${DEBIAN_DESTINATION} \
-        --with-ldap
+        --with-ldap \
+        ${EXTRA_CONFIGURE_FLAGS}
 
 %:
 	dh $@ --parallel
@@ -64,8 +71,8 @@ override_dh_auto_clean:
 	echo "Skipping clean"
 
 override_dh_gencontrol:
-	echo "using version $(VERSION) for binary"
-	dpkg-gencontrol -v$(VERSION) -Pdebian/$(PACKAGE)
+	echo "using version ${GPDB_VERSION} for binary"
+	dpkg-gencontrol -v${GPDB_VERSION} -Pdebian/${PACKAGE}
 
 override_dh_shlibdeps:
 	LD_LIBRARY_PATH=${DEBIAN_DESTINATION}/lib dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info


### PR DESCRIPTION
We are going to pass `--without-zstd` to the gpdb configure flags to
allow GPDB 6.X to build on Ubuntu.

zstd v1.3.1 is provided in Ubuntu 16.04, but is not a recent enough
version to be able to link with GPDB. This forces us to either vendor a
newer version of zstd, or to build without it. We will eventually be
vendoring zstd for the enterprise build of GPDB, but it will likely
never be included with the OSS build on 16.04.

Ubuntu 18.04 provides zstd v1.3.3, which and will at least pass
the gpcontrib/zstd installcheck, so it is possible that we can provide
an OSS build that contains zstd support.

In passing, also rename the ${VERSION} variable to ${GPDB_VERSION} to
disambiguate what version it is referring to.