### PR TITLE
Exclude zstd for gpdb7

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -10,8 +10,9 @@ GPDB_VERSION := $(shell ./getversion | tr " " ".")
 PACKAGE := $(shell cat debian/control | egrep "^Package: " | cut -d " " -f 2)
 
 IS_GPDB6 := $(shell expr ${GPDB_VERSION} : "\(^6\.[0-9]\+\.[0-9]\+\)")
+IS_GPDB7 := $(shell expr ${GPDB_VERSION} : "\(^7\.[0-9]\+\.[0-9]\+\)")
 
-ifdef IS_GPDB6
+ifdef IS_GPDB6 || IS_GPDB7
 	EXTRA_CONFIGURE_FLAGS := --without-zstd
 endif
 


### PR DESCRIPTION
The zstd extension is not currently supportable for the environments being used. Recently Greenplum 6X_STABLE was created and a corresponding 7.0.0-alpha.1 tag created. With that tag, we need to continue to exclude zstd for the time being.