### PR TITLE
Revert "Exclude zstd for gpdb7"

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -10,9 +10,8 @@ GPDB_VERSION := $(shell ./getversion | tr " " ".")
 PACKAGE := $(shell cat debian/control | egrep "^Package: " | cut -d " " -f 2)
 
 IS_GPDB6 := $(shell expr ${GPDB_VERSION} : "\(^6\.[0-9]\+\.[0-9]\+\)")
-IS_GPDB7 := $(shell expr ${GPDB_VERSION} : "\(^7\.[0-9]\+\.[0-9]\+\)")
 
-ifdef IS_GPDB6 || IS_GPDB7
+ifdef IS_GPDB6
 	EXTRA_CONFIGURE_FLAGS := --without-zstd
 endif
 


### PR DESCRIPTION
Reverts greenplum-db/debian-release#5